### PR TITLE
Add flag report-no-exported

### DIFF
--- a/errchkjson_test.go
+++ b/errchkjson_test.go
@@ -32,6 +32,10 @@ func TestNoExportedField(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error setting 'omit-safe' command line flag: %v", err)
 	}
+	err = errchkjson.Flags.Set("report-no-exported", "true")
+	if err != nil {
+		t.Fatalf("error setting 'report-no-exported' command line flag: %v", err)
+	}
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, errchkjson, "noexport")
 }


### PR DESCRIPTION
This flag is needed to disable this check in order to prevent
duplicate check results with staticcheck in golangci-lint.

See:
* https://github.com/golangci/golangci-lint/pull/2349#issuecomment-962695413
* https://staticcheck.io/docs/checks/#SA9005