### PR TITLE
tests: add case for looping structure (stack overflow)

### DIFF
--- a/errchkjson_test.go
+++ b/errchkjson_test.go
@@ -39,3 +39,10 @@ func TestNoExportedField(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, errchkjson, "noexport")
 }
+
+func TestLoop(t *testing.T) {
+	errchkjson := errchkjson.NewAnalyzer()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, errchkjson, "loop")
+}

--- a/testdata/src/loop/a.go
+++ b/testdata/src/loop/a.go
@@ -4,21 +4,15 @@ import (
 	"encoding/json"
 )
 
-type bqSchemaEntry struct {
-	Name        string   `json:"name"`
-	Type        string   `json:"type"`
-	Mode        string   `json:"mode"`
-	Description string   `json:"description"`
-	Fields      bqSchema `json:"fields"`
+type entry struct {
+	Name   string `json:"name"`
+	Fields schema `json:"fields"`
 }
 
-type bqSchema []bqSchemaEntry
+type schema []entry
 
-// JSONMarshalStructWithoutExportedFields contains a struct without exported fields.
+// JSONMarshalStructWithLoop contains a struct with a loop.
 func JSONMarshalStructWithLoop() {
-	var err error
-
-	var withoutExportedFields bqSchema
-	_, err = json.Marshal(withoutExportedFields) // want "Error argument passed to `encoding/json.Marshal` does not contain any exported field"
-	_ = err
+	var structWithLoop schema
+	_, _ = json.Marshal(structWithLoop)
 }

--- a/testdata/src/loop/a.go
+++ b/testdata/src/loop/a.go
@@ -1,0 +1,24 @@
+package example
+
+import (
+	"encoding/json"
+)
+
+type bqSchemaEntry struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Mode        string   `json:"mode"`
+	Description string   `json:"description"`
+	Fields      bqSchema `json:"fields"`
+}
+
+type bqSchema []bqSchemaEntry
+
+// JSONMarshalStructWithoutExportedFields contains a struct without exported fields.
+func JSONMarshalStructWithLoop() {
+	var err error
+
+	var withoutExportedFields bqSchema
+	_, err = json.Marshal(withoutExportedFields) // want "Error argument passed to `encoding/json.Marshal` does not contain any exported field"
+	_ = err
+}


### PR DESCRIPTION
this currently fails with the following error.

unfortunately I don't have time to investigate a fix, but hope this helps with reproducing it.

```
-*- mode: compilation; default-directory: "~/dev/other/errchkjson/" -*-
Compilation started at Thu Jan 27 14:18:22

go test -run='TestLoop$' 
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc02d0004c8 stack=[0xc02d000000, 0xc04d000000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x6985f4, 0x84e620})
	/usr/lib/go/src/runtime/panic.go:1198 +0x71
runtime.newstack()
	/usr/lib/go/src/runtime/stack.go:1088 +0x5ac
runtime.morestack()
	/usr/lib/go/src/runtime/asm_amd64.s:461 +0x8b

goroutine 596 [running]:
go/types.(*Named).under(0xc00875b280)
	/usr/lib/go/src/go/types/decl.go:579 +0x679 fp=0xc02d0004d8 sp=0xc02d0004d0 pc=0x56d359
go/types.under({0x6eee58, 0xc00875b280})
	/usr/lib/go/src/go/types/type.go:909 +0x2f fp=0xc02d0004f8 sp=0xc02d0004d8 pc=0x59d5ef
go/types.asTypeParam({0x6eee58, 0xc00875b280})
	/usr/lib/go/src/go/types/type.go:987 +0x25 fp=0xc02d000518 sp=0xc02d0004f8 pc=0x59da85
go/types.optype({0x6eee58, 0xc00875b280})
	/usr/lib/go/src/go/types/type.go:783 +0x2c fp=0xc02d000558 sp=0xc02d000518 pc=0x59cb2c
go/types.asInterface(...)
	/usr/lib/go/src/go/types/type.go:963
go/types.IsInterface({0x6eee58, 0xc00875b280})
	/usr/lib/go/src/go/types/predicates.go:86 +0x25 fp=0xc02d000578 sp=0xc02d000558 pc=0x587765
go/types.(*Checker).rawLookupFieldOrMethod(0x6eee58, {0x6eee80, 0xc00c517f90}, 0x0, 0x1, {0x697366, 0xb})
	/usr/lib/go/src/go/types/lookup.go:89 +0xea fp=0xc02d000838 sp=0xc02d000578 pc=0x58258a
go/types.(*Checker).missingMethod(0x0, {0x6eee58, 0xc00875b280}, 0xc004a58200, 0x1)
	/usr/lib/go/src/go/types/lookup.go:361 +0x4f4 fp=0xc02d000908 sp=0xc02d000838 pc=0x584134
go/types.MissingMethod(...)
	/usr/lib/go/src/go/types/lookup.go:295
go/types.Implements({0x6eee58, 0xc00875b280}, 0xc0087f00a6)
	/usr/lib/go/src/go/types/api.go:320 +0x33 fp=0xc02d000940 sp=0xc02d000908 pc=0x55af53
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffd6)
	/home/mark/dev/other/errchkjson/errchkjson.go:153 +0x55 fp=0xc02d0009c0 sp=0xc02d000940 pc=0x5b23d5
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffd5)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d000a40 sp=0xc02d0009c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffd4)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d000ac0 sp=0xc02d000a40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffd3)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d000b40 sp=0xc02d000ac0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffd2)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d000bc0 sp=0xc02d000b40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffd1)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d000c40 sp=0xc02d000bc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffd0)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d000cc0 sp=0xc02d000c40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffcf)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d000d40 sp=0xc02d000cc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffce)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d000dc0 sp=0xc02d000d40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffcd)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d000e40 sp=0xc02d000dc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffcc)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d000ec0 sp=0xc02d000e40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffcb)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d000f40 sp=0xc02d000ec0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffca)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d000fc0 sp=0xc02d000f40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffc9)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001040 sp=0xc02d000fc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffc8)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0010c0 sp=0xc02d001040 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffc7)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001140 sp=0xc02d0010c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffc6)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0011c0 sp=0xc02d001140 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffc5)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001240 sp=0xc02d0011c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffc4)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0012c0 sp=0xc02d001240 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffc3)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001340 sp=0xc02d0012c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffc2)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0013c0 sp=0xc02d001340 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffc1)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001440 sp=0xc02d0013c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffc0)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0014c0 sp=0xc02d001440 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffbf)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001540 sp=0xc02d0014c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffbe)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0015c0 sp=0xc02d001540 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffbd)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001640 sp=0xc02d0015c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffbc)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0016c0 sp=0xc02d001640 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffbb)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001740 sp=0xc02d0016c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffba)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0017c0 sp=0xc02d001740 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffb9)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001840 sp=0xc02d0017c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffb8)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0018c0 sp=0xc02d001840 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffb7)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001940 sp=0xc02d0018c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffb6)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0019c0 sp=0xc02d001940 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffb5)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001a40 sp=0xc02d0019c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffb4)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d001ac0 sp=0xc02d001a40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffb3)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001b40 sp=0xc02d001ac0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffb2)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d001bc0 sp=0xc02d001b40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffb1)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001c40 sp=0xc02d001bc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffb0)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d001cc0 sp=0xc02d001c40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffaf)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001d40 sp=0xc02d001cc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffae)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d001dc0 sp=0xc02d001d40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffad)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001e40 sp=0xc02d001dc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffac)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d001ec0 sp=0xc02d001e40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffab)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d001f40 sp=0xc02d001ec0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffaa)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d001fc0 sp=0xc02d001f40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffa9)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002040 sp=0xc02d001fc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffa8)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0020c0 sp=0xc02d002040 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffa7)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002140 sp=0xc02d0020c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffa6)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0021c0 sp=0xc02d002140 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffa5)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002240 sp=0xc02d0021c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffa4)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0022c0 sp=0xc02d002240 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffa3)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002340 sp=0xc02d0022c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffa2)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0023c0 sp=0xc02d002340 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fffa1)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002440 sp=0xc02d0023c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fffa0)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0024c0 sp=0xc02d002440 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff9f)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002540 sp=0xc02d0024c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff9e)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0025c0 sp=0xc02d002540 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff9d)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002640 sp=0xc02d0025c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff9c)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0026c0 sp=0xc02d002640 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff9b)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002740 sp=0xc02d0026c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff9a)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0027c0 sp=0xc02d002740 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff99)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002840 sp=0xc02d0027c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff98)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0028c0 sp=0xc02d002840 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff97)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002940 sp=0xc02d0028c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff96)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0029c0 sp=0xc02d002940 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff95)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002a40 sp=0xc02d0029c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff94)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d002ac0 sp=0xc02d002a40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff93)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002b40 sp=0xc02d002ac0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff92)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d002bc0 sp=0xc02d002b40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff91)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002c40 sp=0xc02d002bc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff90)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d002cc0 sp=0xc02d002c40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff8f)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002d40 sp=0xc02d002cc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff8e)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d002dc0 sp=0xc02d002d40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff8d)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002e40 sp=0xc02d002dc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff8c)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d002ec0 sp=0xc02d002e40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff8b)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d002f40 sp=0xc02d002ec0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff8a)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d002fc0 sp=0xc02d002f40 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff89)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d003040 sp=0xc02d002fc0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff88)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0030c0 sp=0xc02d003040 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff87)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d003140 sp=0xc02d0030c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff86)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0031c0 sp=0xc02d003140 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff85)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d003240 sp=0xc02d0031c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff84)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0032c0 sp=0xc02d003240 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff83)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d003340 sp=0xc02d0032c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff82)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0033c0 sp=0xc02d003340 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff81)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d003440 sp=0xc02d0033c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff80)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0034c0 sp=0xc02d003440 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff7f)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d003540 sp=0xc02d0034c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff7e)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0035c0 sp=0xc02d003540 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff7d)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d003640 sp=0xc02d0035c0 pc=0x5b2a6e
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b280}, 0x3fff7c)
	/home/mark/dev/other/errchkjson/errchkjson.go:186 +0x3fb fp=0xc02d0036c0 sp=0xc02d003640 pc=0x5b277b
github.com/breml/errchkjson.(*errchkjson).jsonSafe(0xc0000bc9d0, {0x6eee58, 0xc00875b200}, 0x3fff7b)
	/home/mark/dev/other/errchkjson/errchkjson.go:205 +0x6ee fp=0xc02d003740 sp=0xc02d0036c0 pc=0x5b2a6e
created by golang.org/x/tools/go/analysis/internal/checker.execAll
	/home/mark/go/pkg/mod/golang.org/x/tools@v0.1.7/go/analysis/internal/checker/checker.go:573 +0x168

goroutine 1 [chan receive]:
testing.(*T).Run(0xc0001064e0, {0x696433, 0x469193}, 0x6a93b8)
	/usr/lib/go/src/testing/testing.go:1307 +0x375
testing.runTests.func1(0xc0001064e0)
	/usr/lib/go/src/testing/testing.go:1598 +0x6e
testing.tRunner(0xc0001064e0, 0xc000117d18)
	/usr/lib/go/src/testing/testing.go:1259 +0x102
testing.runTests(0xc0000d6480, {0x862020, 0x4, 0x4}, {0x48058d, 0x69863a, 0x867cc0})
	/usr/lib/go/src/testing/testing.go:1596 +0x43f
testing.(*M).Run(0xc0000d6480)
	/usr/lib/go/src/testing/testing.go:1504 +0x51d
main.main()
	_testmain.go:51 +0x14b

goroutine 18 [semacquire]:
sync.runtime_Semacquire(0x0)
	/usr/lib/go/src/runtime/sema.go:56 +0x25
sync.(*WaitGroup).Wait(0x0)
	/usr/lib/go/src/sync/waitgroup.go:130 +0x71
golang.org/x/tools/go/analysis/internal/checker.execAll({0xc008bb4740, 0x1, 0xc000312076})
	/home/mark/go/pkg/mod/golang.org/x/tools@v0.1.7/go/analysis/internal/checker/checker.go:576 +0x172
golang.org/x/tools/go/analysis/internal/checker.analyze({0xc008bb4738, 0x1, 0x0}, {0xc000093d68, 0x1, 0xc008bb4738})
	/home/mark/go/pkg/mod/golang.org/x/tools@v0.1.7/go/analysis/internal/checker/checker.go:262 +0x1bf
golang.org/x/tools/go/analysis/internal/checker.TestAnalyzer(0xc0000a6090, {0xc008bb4738, 0xc00009f7d0, 0x1})
	/home/mark/go/pkg/mod/golang.org/x/tools@v0.1.7/go/analysis/internal/checker/checker.go:179 +0x65
golang.org/x/tools/go/analysis/analysistest.Run({0x6ea660, 0xc000106680}, {0xc0000a6090, 0x28}, 0x0, {0xc00009f7d0, 0x1, 0x1})
	/home/mark/go/pkg/mod/golang.org/x/tools@v0.1.7/go/analysis/analysistest/analysistest.go:291 +0xd2
github.com/breml/errchkjson_test.TestLoop(0x0)
	/home/mark/dev/other/errchkjson/errchkjson_test.go:47 +0x8a
testing.tRunner(0xc000106680, 0x6a93b8)
	/usr/lib/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/lib/go/src/testing/testing.go:1306 +0x35a
exit status 2
FAIL	github.com/breml/errchkjson	48.242s

Compilation exited abnormally with code 1 at Thu Jan 27 14:19:11
```